### PR TITLE
Refactor users table to use auto-incrementing integer IDs

### DIFF
--- a/backend/app/Database/Migrations/2025-09-05-231402_CreateUsersTable.php
+++ b/backend/app/Database/Migrations/2025-09-05-231402_CreateUsersTable.php
@@ -10,10 +10,10 @@ class CreateUsersTable extends Migration
     {
         $this->forge->addField([
             'id' => [
-                'type'       => 'CHAR',
-                'constraint' => 36,
-                'null'       => false,
-                'comment'    => 'UUID v4 string',
+                'type'           => 'INT',
+                'constraint'     => 11,
+                'unsigned'       => true,
+                'auto_increment' => true,
             ],
             'first_name' => [
                 'type'       => 'VARCHAR',
@@ -89,7 +89,8 @@ class CreateUsersTable extends Migration
         ]);
 
         $this->forge->addKey('id', true);
-        $this->forge->addKey('email');
+        // Make email unique
+        $this->forge->addUniqueKey('email');
         $this->forge->createTable('users', true);
     }
 

--- a/backend/app/Database/Seeds/ClearDatabaseSeeder.php
+++ b/backend/app/Database/Seeds/ClearDatabaseSeeder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Database\Seeds;
 
 use CodeIgniter\Database\Seeder;
@@ -9,6 +10,7 @@ class ClearDatabaseSeeder extends Seeder
     {
         $db      = \Config\Database::connect();
         $builder = $db->table('funeral_requests');
+        $builder = $db->table('users');
 
         // Use disableForeignKeyChecks if supported by the DB to avoid FK issues
         $db->disableForeignKeyChecks();

--- a/backend/app/Database/Seeds/UsersSeeder.php
+++ b/backend/app/Database/Seeds/UsersSeeder.php
@@ -8,16 +8,7 @@ class UsersSeeder extends Seeder
 {
     public function run()
     {
-        helper('text');
-
-        // Simple UUID v4 generator fallback (if ramsey/uuid not installed)
-        $uuid = function () {
-            // generate 16 bytes (128 bits) and set version to 4
-            $data = random_bytes(16);
-            $data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
-            $data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
-            return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
-        };
+        // relying on DB auto-increment id
 
         $now = date('Y-m-d H:i:s');
 
@@ -26,7 +17,6 @@ class UsersSeeder extends Seeder
         $users = [
             // 3 clients
             [
-                'id' => $uuid(),
                 'first_name' => 'Alice',
                 'middle_name' => 'M',
                 'last_name' => 'Carson',
@@ -40,7 +30,6 @@ class UsersSeeder extends Seeder
                 'updated_at' => $now,
             ],
             [
-                'id' => $uuid(),
                 'first_name' => 'Bob',
                 'middle_name' => null,
                 'last_name' => 'Dawson',
@@ -54,7 +43,6 @@ class UsersSeeder extends Seeder
                 'updated_at' => $now,
             ],
             [
-                'id' => $uuid(),
                 'first_name' => 'Cara',
                 'middle_name' => 'L',
                 'last_name' => 'Evans',
@@ -70,7 +58,6 @@ class UsersSeeder extends Seeder
 
             // 1 embalmer
             [
-                'id' => $uuid(),
                 'first_name' => 'Ethan',
                 'middle_name' => null,
                 'last_name' => 'Miller',
@@ -86,7 +73,6 @@ class UsersSeeder extends Seeder
 
             // 1 driver
             [
-                'id' => $uuid(),
                 'first_name' => 'Darren',
                 'middle_name' => null,
                 'last_name' => 'Rios',
@@ -102,7 +88,6 @@ class UsersSeeder extends Seeder
 
             // 3 staff
             [
-                'id' => $uuid(),
                 'first_name' => 'Sofia',
                 'middle_name' => null,
                 'last_name' => 'Kent',
@@ -116,7 +101,6 @@ class UsersSeeder extends Seeder
                 'updated_at' => $now,
             ],
             [
-                'id' => $uuid(),
                 'first_name' => 'Tina',
                 'middle_name' => null,
                 'last_name' => 'Ng',
@@ -130,7 +114,6 @@ class UsersSeeder extends Seeder
                 'updated_at' => $now,
             ],
             [
-                'id' => $uuid(),
                 'first_name' => 'Marco',
                 'middle_name' => null,
                 'last_name' => 'Reed',
@@ -146,7 +129,6 @@ class UsersSeeder extends Seeder
 
             // 1 florist
             [
-                'id' => $uuid(),
                 'first_name' => 'Flora',
                 'middle_name' => null,
                 'last_name' => 'Bloom',
@@ -162,7 +144,6 @@ class UsersSeeder extends Seeder
 
             // 1 manager
             [
-                'id' => $uuid(),
                 'first_name' => 'Martin',
                 'middle_name' => null,
                 'last_name' => 'Gale',


### PR DESCRIPTION
Change the users table migration to use an auto-incrementing integer for the ID field and update seeders accordingly. This simplifies user ID management by removing the need for UUIDs.