### PR TITLE
Update port mappings for Docker Compose services

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -30,7 +30,7 @@ services:
     image: nginx:alpine
     init: true
     ports:
-      - "8080:80"
+      - "8090:80"
     volumes:
       - ./backend:/var/www/html:ro
       - ./backend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
@@ -50,7 +50,7 @@ services:
   mysql:
     image: mysql:8.0
     ports:
-      - "3307:3306"
+      - "3390:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: app
@@ -69,7 +69,7 @@ services:
     image: phpmyadmin:latest
     profiles: [ "tools" ] # run only if you pass --profile tools
     ports:
-      - "8081:80"
+      - "8091:80"
     environment:
       PMA_HOST: mysql
       PMA_USER: root


### PR DESCRIPTION
### **User description**
Adjust port mappings for nginx, mysql, and phpmyadmin services in the Docker Compose configuration to avoid conflicts.


___

### **PR Type**
Other


___

### **Description**
- Update nginx port mapping from 8080 to 8090

- Change mysql port mapping from 3307 to 3390

- Modify phpmyadmin port mapping from 8081 to 8091


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Compose"] --> B["nginx:8080→8090"]
  A --> C["mysql:3307→3390"]
  A --> D["phpmyadmin:8081→8091"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compose.yaml</strong><dd><code>Update service port mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

compose.yaml

<ul><li>Changed nginx port mapping from 8080:80 to 8090:80<br> <li> Updated mysql port mapping from 3307:3306 to 3390:3306<br> <li> Modified phpmyadmin port mapping from 8081:80 to 8091:80</ul>


</details>


  </td>
  <td><a href="https://github.com/zyx-0314/CI4-template/pull/58/files#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

