### PR TITLE
Remove additional branch references in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Testing
 
 on:
   push:
-    branches: [ "main", "Funeral-Homes-Demo/main" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "Funeral-Homes-Demo/main" ]
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
Streamline the GitHub Actions workflow by removing unnecessary branch references from the push and pull_request triggers.