### PR TITLE
Add database seeder and migration commands

### DIFF
--- a/backend/app/Database/Seeds/ClearDatabaseSeeder.php
+++ b/backend/app/Database/Seeds/ClearDatabaseSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Database\Seeds;
+
+use CodeIgniter\Database\Seeder;
+
+class ClearDatabaseSeeder extends Seeder
+{
+    public function run()
+    {
+        $db      = \Config\Database::connect();
+        $builder = $db->table('funeral_requests');
+        $builder = $db->table('users');
+
+        // Use disableForeignKeyChecks if supported by the DB to avoid FK issues
+        $db->disableForeignKeyChecks();
+        $builder->truncate();
+        $db->enableForeignKeyChecks();
+    }
+}

--- a/backend/app/Database/Seeds/DatabaseSeeder.php
+++ b/backend/app/Database/Seeds/DatabaseSeeder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Database\Seeds;
+
+use CodeIgniter\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run()
+    {
+        $this->call('App\\Database\\Seeds\\ClearDatabaseSeeder');
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -39,6 +39,11 @@
     },
     "scripts": {
         "test": "phpunit",
-        "health": "php spark health:check"
+        "health": "php spark health:check",
+        "migrate": "php spark migrate",
+        "migrate:status": "php spark migrate:status",
+        "seed": "php spark db:seed",
+        "seed:all": "php spark db:seed DatabaseSeeder",
+        "truncate": "php spark db:seed ClearDatabaseSeeder"
     }
 }


### PR DESCRIPTION
Introduce a new `ClearDatabaseSeeder` and `DatabaseSeeder` to facilitate database management. Update the `composer.json` scripts to include migration and seeding commands for easier database operations.