### PR TITLE
Add ClearDatabaseSeeder and update DatabaseSeeder with README modifications

### DIFF
--- a/backend/app/Database/Seeds/ClearDatabaseSeeder.php
+++ b/backend/app/Database/Seeds/ClearDatabaseSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Database\Seeds;
+
+use CodeIgniter\Database\Seeder;
+
+class ClearDatabaseSeeder extends Seeder
+{
+    public function run()
+    {
+        $db = \Config\Database::connect();
+
+        // Order matters: child tables first, then parents
+        // List down your tables here
+        $tablesInOrder = [];
+
+        $db->disableForeignKeyChecks();
+
+        try {
+            foreach ($tablesInOrder as $table) {
+                if (method_exists($db, 'tableExists') && $db->tableExists($table)) {
+                    // TRUNCATE resets AUTO_INCREMENT in MySQL
+                    $db->table($table)->truncate();
+                }
+            }
+        } finally {
+            $db->enableForeignKeyChecks();
+        }
+    }
+}

--- a/backend/app/Database/Seeds/DatabaseSeeder.php
+++ b/backend/app/Database/Seeds/DatabaseSeeder.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Database\Seeds;
+
+use CodeIgniter\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run()
+    {
+        $this->call('App\\Database\\Seeds\\ClearDatabaseSeeder');
+
+        // $this->call('App\\Database\\Seeds\\<name of the seeder here>');
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ These are **sample modules** included (or suggested) for learning how to add fea
 Run the development stack and the app (rebuild if needed):
 
 ```cmd
-docker compose up -d --build
+docker compose up --watch
 ```
 
 Common utility commands (run inside the project root):


### PR DESCRIPTION
Introduce a new `ClearDatabaseSeeder` to facilitate database truncation while maintaining foreign key checks. Update the existing `DatabaseSeeder` to include the new seeder and modify the README to reflect changes in the Docker command.